### PR TITLE
fix Issue #15: brcm firmware in the wrong place

### DIFF
--- a/stage2/install_firmware_nonfree.sh
+++ b/stage2/install_firmware_nonfree.sh
@@ -28,6 +28,8 @@ echo "Installing firmware..."
 if [ ${BRCMONLY-1} -eq 1 ]; then
     echo "Copy brcm only"
     # or it might be too large ...
+    # fix Issue 15
+    mkdir $ROOT_PATH/lib/firmware
     cp -a $BUILD_PATH/firmware-nonfree/brcm $ROOT_PATH/lib/firmware
 else
     cp -a $BUILD_PATH/firmware-nonfree/ $ROOT_PATH/lib/firmware


### PR DESCRIPTION
Description: 
The kernel can't find brcm firmwares when booting, so the wlan0 does't show. dmesg logs see [here](https://i.loli.net/2018/12/15/5c145542c994e.jpg).

When executing [stage2/install_firmware_nonfree.sh](https://github.com/UMRnInside/RPi-arm64/blob/master/stage2/install_firmware_nonfree.sh), `cp -a $BUILD_PATH/firmware-nonfree/brcm $ROOT_PATH/lib/firmware` only copys files in `$BUILD_PATH/firmware-nonfree/brcm` without the brcm folder itself, because `$ROOT_PATH/lib/firmware` does not exist at that time. So after copying, all firmwares (a.k.a. brcmfmac*-sdio.bin) will be inside `$ROOT_PATH/lib/firmware`, instead of inside `$ROOT_PATH/lib/firmware/brcm`.

Solution:
`mkdir $ROOT_PATH/lib/firmware`  before copying.
 😉
